### PR TITLE
Use meson to build rwguide package

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -22,17 +22,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Pages setup
         uses: actions/configure-pages@v5
       - name: Python setup
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
-      - name: Dependencies
-        run: pip install sphinx numpy scipy xarray cffi setuptools
-      - name: Sphinx
-        run: make docs
+          python-version: "3.14"
+      - name: Install package
+        run: pip install .[docs]
+      - name: Build docs with installed package
+        run: sphinx-build -M html "docs/source" "docs"
       - name: Disable Jekyll
         run: touch docs/html/.nojekyll
       - name: Upload artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Build and test package
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Python setup
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package
+        run: pip install .
+      - name: Run a test import
+        run: python -c "import rwguide.zonalization"
+

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ data/PVrz-330K-%deg.nc: src/calculate_pvrz.py src/rwguide/pvgradient/_ext$(PYEXT
 
 # Python 'rwguide' package
 py-clean:
-	rm src/rwguide/*/_ext*
-	rm src/rwguide/*/ext.o
+	rm -f src/rwguide/*/_ext*
+	rm -f src/rwguide/*/ext.o
 
-py-install: py-compile
+py-install:
 	pip install .
 
 py-compile: \

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ src/%/_ext$(PYEXT): src/%/build.py src/%/ext.c
 	cd src && python3 $*/build.py
 
 
-# Documentation
-docs: py-compile
+# Documentation (builds from installed package)
+docs:
 	sphinx-build -M html "docs/source" "docs"
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,22 @@ This repository contains the software to produce all figures of the article: Pol
 
 ## The `rwguide` Python Package
 
-An implementation of rolling zonalization is included in this repository.
-The software can be installed as a standalone Python package.
+> [!TIP]
+> If you are interested in computing (rolling) zonalized background states, start here.
+
+The `rwguide` software can be installed as a standalone Python package.
 Install the package from a clone of the repository:
 
-    $ make py-install
+    $ pip install .
 
-If you are interested in computing (rolling) zonalized background states, start here.
 Visit the [package documentation](https://wavestoweather.github.io/Rolling-Zonalization) for more information.
-
-> [!NOTE]
-> Installation directly with pip does not work with current versions of setuptools, as the build steps for the C-extensions are missing.
-> Please install via the make command provided above, which compiles the extensions first and then installs until a better solution is provided.
-> `make` and `cffi` have to be installed in the environment before running the command.
 
 
 ## How To Run the Data Analysis
 
 > [!TIP]
-> This content of the repository is primarily included to reproduce the datasets and plots of Polster and Wirth (2023).
-> If you are just interesting in using the rwguide package, you do not need to follow these steps.
+> This part of the repository reproduces the datasets and plots of Polster and Wirth (2023).
+> If you are just interesting in using the `rwguide` package, you do not need to follow these steps.
 
 Clone the repository:
 
@@ -43,7 +39,7 @@ Clone the repository:
 ### Software Requirements
 
 > [!WARNING]
-> The specified software environment is out-of-date and changes to the CDS likely mean that some changes are necessary to get the analysis running again.
+> The specified software environment is out-of-date and changes to the CDS likely mean that some changes to the code are necessary to get the analysis running again.
 
 - make
 - C compiler to build Python extensions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,14 +1,7 @@
-# -- Path setup --------------------------------------------------------------
-
-import os
-import sys
-sys.path.insert(0, os.path.abspath("../../src"))
-
-
 # -- Project information -----------------------------------------------------
 
 project = "rwguide"
-copyright = "2023, Christopher Polster"
+copyright = "2025, Christopher Polster"
 author = "Christopher Polster"
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ Setup
 **Requirements:**
 
 - C compiler to build extensions
-- Python 3 with numpy, scipy, xarray, cffi and setuptools packages.
+- Python 3.9 or newer
 
 **Local install:**
 
@@ -36,12 +36,18 @@ Clone or download the `Rolling-Zonalization <https://github.com/wavestoweather/R
 
 .. code-block:: bash
 
-    $ make py-install
+    $ pip install .
 
 from the root of the repository.
 
+
 News
 ----
+
+**Release:** Version 1.2.2 (1 Dec 2025)
+
+- Fix broken package installation.
+
 
 **Release:** Version 1.2 (27 Dec 2023)
 
@@ -59,5 +65,5 @@ News
 Acknowledgements
 ----------------
 
-This software has been created within the Transregional Collaborative Research Center SFB/TRR 165 "Waves to Weather" funded by the German Science Foundation (DFG). https://www.wavestoweather.de/
+This software was created within the Transregional Collaborative Research Center SFB/TRR 165 "Waves to Weather" funded by the German Science Foundation (DFG). https://www.wavestoweather.de/
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,10 @@
+project('rwguide')
+
+add_languages('c')
+
+py = import('python').find_installation(pure: false)
+
+pyext = run_command('python3-config', '--extension-suffix', check: true).stdout().strip()
+
+subdir('src/rwguide')
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=77.0.3", "wheel", "cffi"]
+build-backend = "mesonpy"
+requires = ["meson-python", "cffi>=1.17", "wheel"]
 
 [project]
 name = "rwguide"
@@ -9,9 +9,9 @@ authors = [
 ]
 description = "Rossby waveguide analysis"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 license = { file="LICENSE" }
-dynamic = ["version"]
+version = "1.2.2"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Atmospheric Science",
 ]
 dependencies = [
-    "cffi>=1.15.1",
+    "cffi>=1.17",
     "numpy>=1.24.3",
     "scipy>=1.10.1",
     "xarray>=2022.11.0"
@@ -29,14 +29,4 @@ dependencies = [
 [project.urls]
 documentation = "https://wavestoweather.github.io/Rolling-Zonalization"
 source = "https://github.com/wavestoweather/Rolling-Zonalization"
-
-[tool.setuptools.packages.find]
-where =  ["./src"]
-include = ["rwguide"]
-
-[tool.setuptools.package-data]
-rwguide = ["*/*.so"]
-
-[tool.setuptools.dynamic]
-version = { attr="rwguide.__version__" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = [
     "xarray>=2022.11.0"
 ]
 
+[project.optional-dependencies]
+docs = [
+    "Sphinx>=9"
+]
+
 [project.urls]
 documentation = "https://wavestoweather.github.io/Rolling-Zonalization"
 source = "https://github.com/wavestoweather/Rolling-Zonalization"

--- a/src/rwguide/__init__.py
+++ b/src/rwguide/__init__.py
@@ -1,3 +1,3 @@
 """Python package to detect and analyse Rossby waveguides.""" 
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/src/rwguide/hovmoeller/build.py
+++ b/src/rwguide/hovmoeller/build.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import cffi
 
@@ -31,6 +32,15 @@ ffibuilder.set_source(
     libraries=["m"],
 )
 
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--emit-c-code", type=str, default=None)
+
 if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+    args = parser.parse_args()
+
+    if args.emit_c_code is not None:
+        ffibuilder.emit_c_code(args.emit_c_code)
+    else:
+        ffibuilder.compile(verbose=True)
 

--- a/src/rwguide/hovmoeller/meson.build
+++ b/src/rwguide/hovmoeller/meson.build
@@ -1,0 +1,24 @@
+py.install_sources(
+    '__init__.py',
+    'refined.py',
+    subdir: 'rwguide/hovmoeller'
+)
+
+
+_ext_src = custom_target(
+    command: ['python3', '@INPUT0@', '--emit-c-code', '@OUTPUT@'],
+    input: ['build.py', 'ext.c'],
+    output: '_ext.c',
+    install: false
+)
+
+_ext_dep = declare_dependency(sources: ['ext.c'])
+
+py.extension_module(
+    '_ext',
+    _ext_src,
+    subdir: 'rwguide/hovmoeller',
+    install: true,
+    dependencies: [_ext_dep, py.dependency()]
+)
+

--- a/src/rwguide/meson.build
+++ b/src/rwguide/meson.build
@@ -1,0 +1,21 @@
+py.install_sources(
+    '__init__.py',
+    'bindings.py',
+    'xarray/__init__.py',
+    'xarray/common.py',
+    'xarray/hovmoeller.py',
+    'xarray/pvgradient.py',
+    'xarray/waveactivity.py',
+    'xarray/wavenumber.py',
+    'xarray/zonalization.py',
+    subdir: 'rwguide',
+    preserve_path: true
+)
+
+pyext = run_command('python3-config', '--extension-suffix', check: true).stdout().strip()
+
+subdir('hovmoeller')
+subdir('pvgradient')
+subdir('waveactivity')
+subdir('wavenumber')
+subdir('zonalization')

--- a/src/rwguide/pvgradient/build.py
+++ b/src/rwguide/pvgradient/build.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import cffi
 
@@ -127,6 +128,14 @@ ffibuilder.set_source(
     libraries=["m"],
 )
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--emit-c-code", type=str, default=None)
+
 if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+    args = parser.parse_args()
+
+    if args.emit_c_code is not None:
+        ffibuilder.emit_c_code(args.emit_c_code)
+    else:
+        ffibuilder.compile(verbose=True)
 

--- a/src/rwguide/pvgradient/meson.build
+++ b/src/rwguide/pvgradient/meson.build
@@ -1,0 +1,25 @@
+py.install_sources(
+    '__init__.py',
+    'processing.py',
+    'variables.py',
+    subdir: 'rwguide/pvgradient'
+)
+
+
+_ext_src = custom_target(
+    command: ['python3', '@INPUT0@', '--emit-c-code', '@OUTPUT0@'],
+    input: ['build.py', 'ext.c'],
+    output: '_ext.c',
+    install: false
+)
+
+_ext_dep = declare_dependency(sources: ['ext.c'])
+
+py.extension_module(
+    '_ext',
+    _ext_src,
+    subdir: 'rwguide/pvgradient',
+    install: true,
+    dependencies: [_ext_dep, py.dependency()]
+)
+

--- a/src/rwguide/waveactivity/build.py
+++ b/src/rwguide/waveactivity/build.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import cffi
 
@@ -27,6 +28,13 @@ ffibuilder.set_source(
     libraries=["m"],
 )
 
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+parser = argparse.ArgumentParser()
+parser.add_argument("--emit-c-code", type=str, default=None)
 
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.emit_c_code is not None:
+        ffibuilder.emit_c_code(args.emit_c_code)
+    else:
+        ffibuilder.compile(verbose=True)

--- a/src/rwguide/waveactivity/meson.build
+++ b/src/rwguide/waveactivity/meson.build
@@ -1,0 +1,24 @@
+py.install_sources(
+    '__init__.py',
+    'lwa.py',
+    subdir: 'rwguide/waveactivity'
+)
+
+
+_ext_src = custom_target(
+    command: ['python3', '@INPUT0@', '--emit-c-code', '@OUTPUT@'],
+    input: ['build.py', 'ext.c'],
+    output: '_ext.c',
+    install: false
+)
+
+_ext_dep = declare_dependency(sources: ['ext.c'])
+
+py.extension_module(
+    '_ext',
+    _ext_src,
+    subdir: 'rwguide/waveactivity',
+    install: true,
+    dependencies: [_ext_dep, py.dependency()]
+)
+

--- a/src/rwguide/wavenumber/build.py
+++ b/src/rwguide/wavenumber/build.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import cffi
 
@@ -19,6 +20,13 @@ ffibuilder.set_source(
     libraries=["m"],
 )
 
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+parser = argparse.ArgumentParser()
+parser.add_argument("--emit-c-code", type=str, default=None)
 
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.emit_c_code is not None:
+        ffibuilder.emit_c_code(args.emit_c_code)
+    else:
+        ffibuilder.compile(verbose=True)

--- a/src/rwguide/wavenumber/meson.build
+++ b/src/rwguide/wavenumber/meson.build
@@ -1,0 +1,24 @@
+py.install_sources(
+    '__init__.py',
+    'wavenumber.py',
+    subdir: 'rwguide/wavenumber'
+)
+
+
+_ext_src = custom_target(
+    command: ['python3', '@INPUT0@', '--emit-c-code', '@OUTPUT@'],
+    input: ['build.py', 'ext.c'],
+    output: '_ext.c',
+    install: false
+)
+
+_ext_dep = declare_dependency(sources: ['ext.c'])
+
+py.extension_module(
+    '_ext',
+    _ext_src,
+    subdir: 'rwguide/wavenumber',
+    install: true,
+    dependencies: [_ext_dep, py.dependency()]
+)
+

--- a/src/rwguide/zonalization/build.py
+++ b/src/rwguide/zonalization/build.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import cffi
 
@@ -51,6 +52,13 @@ ffibuilder.set_source(
     libraries=["m"],
 )
 
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+parser = argparse.ArgumentParser()
+parser.add_argument("--emit-c-code", type=str, default=None)
 
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.emit_c_code is not None:
+        ffibuilder.emit_c_code(args.emit_c_code)
+    else:
+        ffibuilder.compile(verbose=True)

--- a/src/rwguide/zonalization/meson.build
+++ b/src/rwguide/zonalization/meson.build
@@ -1,0 +1,26 @@
+py.install_sources(
+    '__init__.py',
+    'density.py',
+    'weighting.py',
+    'zonalize.py',
+    subdir: 'rwguide/zonalization'
+)
+
+
+_ext_src = custom_target(
+    command: ['python3', '@INPUT0@', '--emit-c-code', '@OUTPUT@'],
+    input: ['build.py', 'ext.c'],
+    output: '_ext.c',
+    install: false
+)
+
+_ext_dep = declare_dependency(sources: ['ext.c'])
+
+py.extension_module(
+    '_ext',
+    _ext_src,
+    subdir: 'rwguide/zonalization',
+    install: true,
+    dependencies: [_ext_dep, py.dependency()]
+)
+


### PR DESCRIPTION
Hoping to address #1 with this, since 1c1effb isn't a good workaround.

- [x] Use meson build system instead of setuptools
- [x] Automated build tests with Python version matrix
- [x] Build docs from installed package, not from src/

Unfortunately, the meson backend doesn't support dynamic versioning.